### PR TITLE
Remove check for uClibc (FB6591 uses glibc)

### DIFF
--- a/src/pkpwd.c
+++ b/src/pkpwd.c
@@ -24,11 +24,6 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic error "-Wfatal-errors"
 
-#if !defined(__UCLIBC__)
-#error This library is designed to work with the uClibc library on a FRITZ!OS device.
-#pragma GCC error "Compilation aborted."
-#endif
-
 #pragma GCC diagnostic pop
 
 #include <stddef.h>


### PR DESCRIPTION
Not sure if that check had a specific purpose, but it fails on the 6591 which uses glibc.